### PR TITLE
add springboot client configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ These instructions are for users who need template files with client application
 
    * [Java-based client](clients/cloud/java.config) or [Java-based client with Confluent Cloud Schema Registry](clients/cloud/java-sr.config): e.g., Java, Groovy, Kotlin, Scala, Clojure
    * [librdkafka-based client](clients/cloud/librdkafka.config) or [librdkafka-based client with Confluent Cloud Schema Registry](clients/cloud/librdkafka-sr.config): e.g., Python, Go, Ruby, Node, kafkacat, .NET, C
+   * [Springboot client](clients/cloud/springboot.config) or [Springboot client with Confluent Cloud Schema Registry](clients/cloud/springboot-sr.config)
    * [Confluent Platform component](clients/cloud/java.config) or [Confluent Platform component with Confluent Cloud Schema Registry](clients/cloud/java-sr.config): e.g., Confluent CLI, Apache Kafka commands, kafka-connect-datagen, ksql-datagen 
 
 2. Copy the file locally.
@@ -42,6 +43,7 @@ These instructions are for users who need template files with client application
 
    * [Java-based client](clients/local/java.config) or [Java-based client with Confluent Schema Registry](clients/local/java-sr.config): e.g., Java, Groovy, Kotlin, Scala, Clojure
    * [librdkafka-based client](clients/local/librdkafka.config) or [librdkafka-based client with Confluent Schema Registry](clients/local/librdkafka-sr.config): e.g., Python, Go, Ruby, Node, kafkacat, .NET, C
+   * [Springboot client](clients/local/springboot.config) or [Springboot client with Confluent Cloud Schema Registry](clients/local/springboot-sr.config)
    * [Confluent Platform component](clients/local/java.config) or [Confluent Platform component with Confluent Schema Registry](clients/local/java-sr.config): e.g., Confluent CLI, Apache Kafka commands, kafka-connect-datagen, ksql-datagen
 
 2. Copy the file locally.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These instructions are for users who need template files with client application
 
    * [Java-based client](clients/local/java.config) or [Java-based client with Confluent Schema Registry](clients/local/java-sr.config): e.g., Java, Groovy, Kotlin, Scala, Clojure
    * [librdkafka-based client](clients/local/librdkafka.config) or [librdkafka-based client with Confluent Schema Registry](clients/local/librdkafka-sr.config): e.g., Python, Go, Ruby, Node, kafkacat, .NET, C
-   * [Springboot client](clients/local/springboot.config) or [Springboot client with Confluent Cloud Schema Registry](clients/local/springboot-sr.config)
+   * [Springboot client](clients/local/springboot.config) or [Springboot client with Confluent Schema Registry](clients/local/springboot-sr.config)
    * [Confluent Platform component](clients/local/java.config) or [Confluent Platform component with Confluent Schema Registry](clients/local/java-sr.config): e.g., Confluent CLI, Apache Kafka commands, kafka-connect-datagen, ksql-datagen
 
 2. Copy the file locally.

--- a/clients/cloud/springboot-sr.config
+++ b/clients/cloud/springboot-sr.config
@@ -1,0 +1,16 @@
+# Kafka
+spring.kafka.properties.ssl.endpoint.identification.algorithm=https
+spring.kafka.properties.sasl.mechanism=PLAIN
+spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+spring.kafka.properties.security.protocol=SASL_SSL
+# Schema Registry 
+spring.kafka.properties.basic.auth.credentials.source=USER_INFO
+spring.kafka.properties.schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+spring.kafka.properties.schema.registry.url=https://{{ SR_ENDPOINT }}
+# producer configuration
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+# consumer configuration 
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer

--- a/clients/cloud/springboot.config
+++ b/clients/cloud/springboot.config
@@ -1,0 +1,6 @@
+# Kafka
+spring.kafka.properties.ssl.endpoint.identification.algorithm=https
+spring.kafka.properties.sasl.mechanism=PLAIN
+spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+spring.kafka.properties.security.protocol=SASL_SSL

--- a/clients/local/springboot-sr.config
+++ b/clients/local/springboot-sr.config
@@ -1,0 +1,11 @@
+# Kafka
+spring.kafka.properties.bootstrap.servers=localhost:9092
+
+# Confluent Schema Registry
+spring.kafka.properties.schema.registry.url=http://localhost:8081
+# producer configuration
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+# consumer configuration 
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer

--- a/clients/local/springboot.config
+++ b/clients/local/springboot.config
@@ -1,0 +1,2 @@
+# Kafka
+spring.kafka.properties.bootstrap.servers=localhost:9092


### PR DESCRIPTION
From ticket: 
The client config example for Spring Boot should be updated with the following:
```
# Kafka
spring.kafka.properties.ssl.endpoint.identification.algorithm=https
spring.kafka.properties.sasl.mechanism=PLAIN
spring.kafka.properties.bootstrap.servers=${BOOTSTRAP_SERVERS}
spring.kafka.properties.sasl.jaas.config=${SASL_JAAS_CONFIG}
spring.kafka.properties.security.protocol=SASL_SSL
# Schema Registry 
spring.kafka.properties.basic.auth.credentials.source=USER_INFO
spring.kafka.properties.schema.registry.basic.auth.user.info=${SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO}
spring.kafka.properties.schema.registry.url=${SCHEMA_REGISTRY_URL}
# producer configuration
spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
# consumer configuration 
spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
```
(updated the configuration parameters to the correct format)