### PR TITLE
Tweak Cloud Java client configs for better behavior

### DIFF
--- a/clients/cloud/java-sr.config
+++ b/clients/cloud/java-sr.config
@@ -2,8 +2,9 @@
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-ssl.endpoint.identification.algorithm=https
 sasl.mechanism=PLAIN
+acks=all
+linger.ms=5
 
 # Confluent Cloud Schema Registry
 schema.registry.url=https://{{ SR_ENDPOINT }}

--- a/clients/cloud/java.config
+++ b/clients/cloud/java.config
@@ -1,7 +1,9 @@
-# Kafka
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
 sasl.mechanism=PLAIN
+client.dns.lookup=use_all_dns_ips
+
+# Kafka producer
 acks=all
 linger.ms=5

--- a/clients/cloud/java.config
+++ b/clients/cloud/java.config
@@ -1,3 +1,4 @@
+# Kafka client
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";

--- a/clients/cloud/java.config
+++ b/clients/cloud/java.config
@@ -2,5 +2,6 @@
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-ssl.endpoint.identification.algorithm=https
 sasl.mechanism=PLAIN
+acks=all
+linger.ms=5


### PR DESCRIPTION
- Add acks=all to avoid data loss during kafka rolls (librdkafka defaults to
acks=all since 1.0).
- Add linger.ms=5 to improve batching with nearly no impact to latency.
- Remove ssl.endpoint.identification.algorithm as it matches the default
since Apache Kafka 2.0 and it's not strictly required (i.e. things
work without it).